### PR TITLE
Fixing aspect ratio issue

### DIFF
--- a/Assets/SLR-GTk/Package/Scripts/Camera/StreamCamera.cs
+++ b/Assets/SLR-GTk/Package/Scripts/Camera/StreamCamera.cs
@@ -52,7 +52,7 @@ namespace Camera {
             ISO:
             
             // TODO - best resolution
-            webCamTexture = new WebCamTexture(currentDevice.Value.name, 720, 720, 30);
+            webCamTexture = new WebCamTexture(currentDevice.Value.name, 1280, 720, 30);
             
             
             if (webCamTexture.graphicsFormat == GraphicsFormat.R8G8B8A8_UNorm);

--- a/Assets/SLR-GTk/Package/Scripts/Camera/StreamCamera.cs
+++ b/Assets/SLR-GTk/Package/Scripts/Camera/StreamCamera.cs
@@ -52,7 +52,7 @@ namespace Camera {
             ISO:
             
             // TODO - best resolution
-            webCamTexture = new WebCamTexture(currentDevice.Value.name, 1280, 720, 30);
+            webCamTexture = new WebCamTexture(currentDevice.Value.name, 720, 720, 30);
             
             
             if (webCamTexture.graphicsFormat == GraphicsFormat.R8G8B8A8_UNorm);

--- a/Assets/Scenes/SignPrompt.unity
+++ b/Assets/Scenes/SignPrompt.unity
@@ -119,6 +119,25 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &146746675 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4681745135316418996, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+  m_PrefabInstance: {fileID: 1721802478}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &146746679
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 146746675}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.AspectRatioFitter
+  m_AspectMode: 3
+  m_AspectRatio: 1.3620912
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -225,6 +244,25 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   engine: {fileID: 1721802479}
+--- !u!1 &831210564 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6225034367573357115, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+  m_PrefabInstance: {fileID: 1721802478}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &831210569
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 831210564}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.AspectRatioFitter
+  m_AspectMode: 3
+  m_AspectRatio: 1.7777778
 --- !u!1 &1305022940
 GameObject:
   m_ObjectHideFlags: 0
@@ -529,6 +567,38 @@ PrefabInstance:
       propertyPath: m_Name
       value: SimpleSLREngine
       objectReference: {fileID: 0}
+    - target: {fileID: 3636808871842826230, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3636808871842826230, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3636808871842826230, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3636808871842826230, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3636808871842826230, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3636808871842826230, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: -1122.746
+      objectReference: {fileID: 0}
+    - target: {fileID: 3636808871842826230, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3636808871842826230, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -471
+      objectReference: {fileID: 0}
     - target: {fileID: 3685327762526949191, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
       propertyPath: m_text
       value: 
@@ -573,6 +643,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4653650195178649633, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_margin.z
+      value: 3.8033752
+      objectReference: {fileID: 0}
     - target: {fileID: 4681745135316418996, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
       propertyPath: m_Name
       value: Border
@@ -589,10 +663,132 @@ PrefabInstance:
       propertyPath: m_Color.r
       value: 0.8018868
       objectReference: {fileID: 0}
+    - target: {fileID: 8784842472121529906, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784842472121529906, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784842472121529906, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784842472121529906, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784842472121529906, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784842472121529906, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784842472121529906, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784842472121529906, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784842472121529906, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8968258265492319015, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8968258265492319015, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8968258265492319015, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8968258265492319015, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8968258265492319015, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8968258265492319015, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8968258265492319015, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8968258265492319015, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8968258265492319015, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8968258265492319015, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8968258265492319015, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8968258265492319015, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9111544012114102095, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9111544012114102095, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9111544012114102095, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9111544012114102095, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9111544012114102095, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9111544012114102095, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: -1121.0854
+      objectReference: {fileID: 0}
+    - target: {fileID: 9111544012114102095, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9111544012114102095, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -336
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 4681745135316418996, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 146746679}
+    - targetCorrespondingSourceObject: {fileID: 6225034367573357115, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 831210569}
   m_SourcePrefab: {fileID: 100100000, guid: 497d5c774c3ce4f1ca5df896393cac60, type: 3}
 --- !u!114 &1721802479 stripped
 MonoBehaviour:

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "2.9.3",
     "com.unity.feature.2d": "2.0.1",
     "com.unity.ide.rider": "3.0.39",
     "com.unity.ide.visualstudio": "2.0.23",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -106,13 +106,6 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.collab-proxy": {
-      "version": "2.9.3",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
     "com.unity.collections": {
       "version": "2.5.7",
       "depth": 2,

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@
 ---
 
 ## Common Issues / Known Bugs
-- SLR camera appears overly zoomed in
 - No explicit UI feedback for failed sign recognition
 - UI layout is not yet optimized and may feel cluttered
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,6 @@
 4. Use the mouse to control the fishing bobber
 5. Enable webcam-access if prompted
 6. Perform the prompted sign and press **spacebar** to submit
-
-> **Note:** The SLR camera view is currently very zoomed in due to a known issue.
-
 ---
 
 ## Toolkit Integration Summary


### PR DESCRIPTION
## Overview
- Fixed aspect ratio issue causing webcam to appear zoomed in
- Removed Unity VCS package (not being used)

## Explanation
The reason why this issue existed is that the webcam size is fixed within the SLR package to 1280x720 (16:9 ratio). We were setting the webcam to a 1:1 ratio within the scene, causing it to be stretched and appear zoomed in. I fixed the issue by using an AspectRatioFitter component that forces the webcam in the scene to be 16:9.

## Testing
### Before
<img width="696" height="1232" alt="Screenshot 2026-03-04 at 12 03 50 PM" src="https://github.com/user-attachments/assets/efc5c7c9-02f2-4ac5-b67f-b7b34e28891c" />

### After
<img width="696" height="1232" alt="Screenshot 2026-03-04 at 12 00 52 PM" src="https://github.com/user-attachments/assets/942bb256-34fe-4e7e-9a2e-bede06284d50" />
